### PR TITLE
[DPS-366] load and resolve refs

### DIFF
--- a/cmd/dp/data_products.go
+++ b/cmd/dp/data_products.go
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package dp
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/snowplow-product/snowplow-cli/internal/config"
+	snplog "github.com/snowplow-product/snowplow-cli/internal/logging"
+	"github.com/spf13/cobra"
+)
+
+var DataProductsCmd = &cobra.Command{
+	Use:     "data-products",
+	Aliases: []string{"dp"},
+	Short:   "Work with Snowplow data products",
+	Example: `  $ snowplow-cli data-products validate`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := snplog.InitLogging(cmd); err != nil {
+			return err
+		}
+
+		if err := config.InitConsoleConfig(cmd); err != nil {
+			slog.Error("config failure", "error", err)
+			os.Exit(1)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	config.InitConsoleFlags(DataProductsCmd)
+}

--- a/cmd/dp/validate.go
+++ b/cmd/dp/validate.go
@@ -70,7 +70,10 @@ var validateCmd = &cobra.Command{
 
 		slog.Debug("validating from", "paths", searchPaths, "files", possibleFiles)
 
-		lookup.SlogValidations(basePath)
+		err = lookup.SlogValidations(basePath)
+		if err != nil {
+			snplog.LogFatal(err)
+		}
 
 		if ghOut {
 			err := lookup.GhAnnotateValidations(basePath)

--- a/cmd/dp/validate.go
+++ b/cmd/dp/validate.go
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package dp
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	snplog "github.com/snowplow-product/snowplow-cli/internal/logging"
+	"github.com/snowplow-product/snowplow-cli/internal/util"
+	"github.com/snowplow-product/snowplow-cli/internal/validation"
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [paths...]",
+	Short: "Validate data structures with BDP Console",
+	Args:  cobra.ArbitraryArgs,
+	Long:  `Sends all data products and source applications from <path> for validation by BDP Console.`,
+	Example: `  $ snowplow-cli dp validate ./data-products ./source-applications
+  $ snowplow-cli dp validate ./src`,
+	Run: func(cmd *cobra.Command, args []string) {
+		/*
+			apiKeyId, _ := cmd.Flags().GetString("api-key-id")
+			apiKeySecret, _ := cmd.Flags().GetString("api-key")
+			host, _ := cmd.Flags().GetString("host")
+			org, _ := cmd.Flags().GetString("org-id")
+		*/
+		ghOut, _ := cmd.Flags().GetBool("gh-annotate")
+
+		if len(args) == 0 {
+			snplog.LogFatal(errors.New("no source directories supplied"))
+		}
+
+		searchPaths := []string{}
+
+		searchPaths = append(searchPaths, args...)
+
+		files, err := util.MaybeResourcesfromPaths(searchPaths)
+		if err != nil {
+			snplog.LogFatal(err)
+		}
+
+		possibleFiles := []string{}
+		for n := range files {
+			possibleFiles = append(possibleFiles, n)
+		}
+
+		arg0, err := os.Executable()
+		if err != nil {
+			snplog.LogFatal(err)
+		}
+		basePath := filepath.Dir(arg0)
+
+		lookup, err := validation.NewDPLookup(files)
+		if err != nil {
+			snplog.LogFatal(err)
+		}
+
+		slog.Debug("validating from", "paths", searchPaths, "files", possibleFiles)
+
+		lookup.SlogValidations(basePath)
+
+		if ghOut {
+			err := lookup.GhAnnotateValidations(basePath)
+			if err != nil {
+				snplog.LogFatal(err)
+			}
+		}
+
+		numErrors := lookup.ValidationErrorCount()
+
+		if numErrors > 0 {
+			snplog.LogFatal(fmt.Errorf("validation failed %d errors", numErrors))
+		} else {
+			dpCount := 0
+			for range lookup.DataProducts {
+				dpCount++
+			}
+			saCount := 0
+			for range lookup.SourceApps {
+				saCount++
+			}
+			slog.Info("validation", "msg", "success", "data products found", dpCount, "source applications found", saCount)
+		}
+	},
+}
+
+func init() {
+	DataProductsCmd.AddCommand(validateCmd)
+
+	validateCmd.PersistentFlags().Bool("gh-annotate", false, "Output suitable for github workflow annotation (ignores -s)")
+}

--- a/cmd/dp/validate.go
+++ b/cmd/dp/validate.go
@@ -11,7 +11,6 @@
 package dp
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -39,11 +38,12 @@ var validateCmd = &cobra.Command{
 		*/
 		ghOut, _ := cmd.Flags().GetBool("gh-annotate")
 
-		if len(args) == 0 {
-			snplog.LogFatal(errors.New("no source directories supplied"))
-		}
-
 		searchPaths := []string{}
+
+		if len(args) == 0 {
+			searchPaths = append(searchPaths, "data-products")
+			slog.Debug("validation", "msg", "no path provided, using default (./data-products)")
+		}
 
 		searchPaths = append(searchPaths, args...)
 
@@ -68,7 +68,7 @@ var validateCmd = &cobra.Command{
 			snplog.LogFatal(err)
 		}
 
-		slog.Debug("validating from", "paths", searchPaths, "files", possibleFiles)
+		slog.Debug("validation", "msg", "from", "paths", searchPaths, "files", possibleFiles)
 
 		err = lookup.SlogValidations(basePath)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/snowplow-product/snowplow-cli/cmd/dp"
 	"github.com/snowplow-product/snowplow-cli/cmd/ds"
 	"github.com/snowplow-product/snowplow-cli/internal/util"
 	"github.com/spf13/cobra"
@@ -47,4 +48,5 @@ Then on:
 	RootCmd.PersistentFlags().BoolP("silent", "s", false, "Disable output")
 	RootCmd.PersistentFlags().Bool("json-output", false, "Log output as json")
 	RootCmd.AddCommand(ds.DataStructuresCmd)
+	RootCmd.AddCommand(dp.DataProductsCmd)
 }

--- a/internal/model/data_products.go
+++ b/internal/model/data_products.go
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package model
+
+type EventSpec struct {
+	ResourceName       string
+	SourceApplications []map[string]string
+}
+
+type DataProductData struct {
+	SourceApplications  []map[string]string
+	EventSpecifications []EventSpec
+}
+
+type DataProduct struct {
+	ResourceType string
+	ApiVersion   string
+	Data         DataProductData
+}
+
+type SourceApp struct {
+	ResourceType string
+	ApiVersion   string
+	ResourceName string
+}
+

--- a/internal/util/testdata/data-products/data-product.yml
+++ b/internal/util/testdata/data-products/data-product.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+resourceType: data-product
+resourceName: d066a9a7-e6c4-4d72-9a93-1418746f5279
+data:
+  name: Data Product number 1
+  sourceApplications:
+    - $ref: ./source-application.yml
+  domain: Data Products
+  description: This Data Product describes a data product
+  eventSpecifications:
+    - resourceName: e066a9a7-e6c4-4d72-9a93-1418746f5278
+      sourceApplications:
+        - $ref: ./source-application.yml
+      name: event spec 1
+      triggers:
+        - description: number 1 trigger
+      event:
+        source: iglu:io.snowplow/button_click_custom/jsonschema/1-1-0

--- a/internal/util/testdata/data-products/source-application.yml
+++ b/internal/util/testdata/data-products/source-application.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+resourceType: source-application
+resourceName: s066a9a7-e6c4-4d72-9a93-1418746f5279
+data:
+  name: App
+  description: Source Application representing the web app
+  appIds:
+  - app
+  - app-qa
+  entities:
+    tracked:
+    - source: iglu:io.snowplow/frontend_version/jsonschema/1-0-0
+      minCardinality: 1
+    - source: iglu:io.snowplow/organization/jsonschema/1-0-0
+      minCardinality: 1
+    - source: iglu:io.snowplow/user/jsonschema/1-0-1
+      minCardinality: 1
+    enriched: []

--- a/internal/util/testdata/data-products/sub-dir-dp/data-product.yml
+++ b/internal/util/testdata/data-products/sub-dir-dp/data-product.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+resourceType: data-product
+resourceName: e066a9a7-e6c4-4d72-9a93-1418746f5279
+data:
+  name: Data Product number 2
+  sourceApplications:
+    - $ref: ../source-application.yml
+  domain: Data Products
+  description: This Data Product describes a data product
+  eventSpecifications:
+    - resourceName: e066a9a7-e6c4-4d72-9a93-1418746f5278
+      sourceApplications:
+        - $ref: ../source-application.yml
+      name: event spec 1
+      triggers:
+        - description: number 1 trigger
+      event:
+        source: iglu:io.snowplow/button_click_custom/jsonschema/1-1-0

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -12,6 +12,8 @@ package util
 
 import (
 	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -56,4 +58,31 @@ func Test_DataStructuresFromPathsFailNotASchema(t *testing.T) {
 	if err == nil {
 		t.Fatal(err)
 	}
+}
+
+func Test_MaybeResourcesfromPaths(t *testing.T) {
+	saPath, _ := filepath.Abs(filepath.Join("testdata", "data-products", "source-application.yml"))
+	dp1Path, _ := filepath.Abs(filepath.Join("testdata", "data-products", "data-product.yml"))
+	dp2Path, _ := filepath.Abs(filepath.Join("testdata", "data-products", "sub-dir-dp", "data-product.yml"))
+
+	paths := []string{
+		filepath.Join("testdata", "data-products"),
+	}
+
+	dps, err := MaybeResourcesfromPaths(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys := []string{}
+	for k := range dps {
+		keys = append(keys, k)
+	}
+
+	for _, p := range []string{ saPath, dp1Path, dp2Path } {
+		if !slices.Contains(keys, p) {
+			t.Fatal("missing path", p)
+		}
+	}
+
 }

--- a/internal/validation/local_dp_validation.go
+++ b/internal/validation/local_dp_validation.go
@@ -46,7 +46,7 @@ func NewDPLookup(dp map[string]map[string]any) (*DPLookup, error) {
 		v := DPValidations{}
 
 		if apiV, ok := maybeDp["apiVersion"]; !ok || apiV != "v1" {
-			v.Info = append(v.Info, fmt.Sprintf("ignoring, unknown or missing apiVersion: %s", apiV))
+			v.Errors = append(v.Errors, fmt.Sprintf("ignoring, unknown or missing apiVersion: %s", apiV))
 			continue
 		}
 
@@ -67,7 +67,7 @@ func NewDPLookup(dp map[string]map[string]any) (*DPLookup, error) {
 					v.Errors = append(v.Errors, fmt.Sprintf("failed to decode source application %e", err))
 				}
 			default:
-				v.Errors = append(v.Errors, fmt.Sprintf("ignoring, unknown resourceType: %s", resourceType))
+				v.Debug = append(v.Debug, fmt.Sprintf("ignoring, unknown resourceType: %s", resourceType))
 			}
 		} else {
 			v.Errors = append(v.Errors, "missing resourceType")

--- a/internal/validation/local_dp_validation.go
+++ b/internal/validation/local_dp_validation.go
@@ -46,7 +46,7 @@ func NewDPLookup(dp map[string]map[string]any) (*DPLookup, error) {
 		v := DPValidations{}
 
 		if apiV, ok := maybeDp["apiVersion"]; !ok || apiV != "v1" {
-			v.Debug = append(v.Debug, fmt.Sprintf("ignoring, unknown or missing apiVersion: %s", apiV))
+			v.Info = append(v.Info, fmt.Sprintf("ignoring, unknown or missing apiVersion: %s", apiV))
 			continue
 		}
 
@@ -67,10 +67,10 @@ func NewDPLookup(dp map[string]map[string]any) (*DPLookup, error) {
 					v.Errors = append(v.Errors, fmt.Sprintf("failed to decode source application %e", err))
 				}
 			default:
-				v.Debug = append(v.Debug, fmt.Sprintf("ignoring, unknown resourceType: %s", resourceType))
+				v.Errors = append(v.Errors, fmt.Sprintf("ignoring, unknown resourceType: %s", resourceType))
 			}
 		} else {
-			v.Debug = append(v.Debug, "missing resourceType")
+			v.Errors = append(v.Errors, "missing resourceType")
 		}
 
 		validation[f] = v

--- a/internal/validation/local_dp_validation.go
+++ b/internal/validation/local_dp_validation.go
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package validation
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	snplog "github.com/snowplow-product/snowplow-cli/internal/logging"
+	"github.com/snowplow-product/snowplow-cli/internal/model"
+)
+
+type DPLookup struct {
+	DataProducts map[string]model.DataProduct
+	SourceApps   map[string]model.SourceApp
+
+	Validations map[string]DPValidations
+}
+
+type DPValidations struct {
+	Errors   []string
+	Warnings []string
+	Info     []string
+	Debug    []string
+}
+
+func NewDPLookup(dp map[string]map[string]any) (*DPLookup, error) {
+
+	probablyDps := map[string]model.DataProduct{}
+	probablySap := map[string]model.SourceApp{}
+	validation := map[string]DPValidations{}
+
+	for f, maybeDp := range dp {
+		v := DPValidations{}
+
+		if apiV, ok := maybeDp["apiVersion"]; !ok || apiV != "v1" {
+			v.Debug = append(v.Debug, fmt.Sprintf("ignoring, unknown or missing apiVersion: %s", apiV))
+			continue
+		}
+
+		if resourceType, ok := maybeDp["resourceType"]; ok {
+			switch resourceType {
+			case "data-product":
+				var dp model.DataProduct
+				if err := mapstructure.Decode(maybeDp, &dp); err == nil {
+					probablyDps[f] = dp
+				} else {
+					v.Errors = append(v.Errors, fmt.Sprintf("failed to decode data product %e", err))
+				}
+			case "source-application":
+				var sa model.SourceApp
+				if err := mapstructure.Decode(maybeDp, &sa); err == nil {
+					probablySap[f] = sa
+				} else {
+					v.Errors = append(v.Errors, fmt.Sprintf("failed to decode source application %e", err))
+				}
+			default:
+				v.Debug = append(v.Debug, fmt.Sprintf("ignoring, unknown resourceType: %s", resourceType))
+			}
+		} else {
+			v.Debug = append(v.Debug, "missing resourceType")
+		}
+
+		validation[f] = v
+	}
+
+	result := &DPLookup{probablyDps, probablySap, validation}
+	err := result.resolveRefs()
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (lookup *DPLookup) allSourceAppsRelativeTo(filename string) ([]string, error) {
+	relativeSas := []string{}
+	for path := range lookup.SourceApps {
+		relPath, err := filepath.Rel(filepath.Dir(filename), path)
+		if err != nil {
+			return nil, err
+		}
+		relativeSas = append(relativeSas, relPath)
+	}
+
+	return relativeSas, nil
+
+}
+
+func (lookup *DPLookup) resolveRefs() error {
+	for dpFile, dp := range lookup.DataProducts {
+
+		resolvedSas := []string{}
+
+		v, ok := lookup.Validations[dpFile]
+		if !ok {
+			v = DPValidations{}
+		}
+
+		for _, ref := range dp.Data.SourceApplications {
+			if saRef, ok := ref["$ref"]; ok {
+				absPath, err := filepath.Abs(filepath.Join(filepath.Dir(dpFile), saRef))
+				if err != nil {
+					return err
+				}
+
+				if _, ok := lookup.SourceApps[absPath]; ok {
+					ref["$ref"] = absPath
+					resolvedSas = append(resolvedSas, absPath)
+				} else {
+					available, err := lookup.allSourceAppsRelativeTo(dpFile)
+					if err != nil {
+						return err
+					}
+					v.Errors = append(v.Errors, fmt.Sprintf("source application $ref not found %s, available list %v", saRef, available))
+				}
+			}
+		}
+		for _, spec := range dp.Data.EventSpecifications {
+			for _, ref := range spec.SourceApplications {
+				if saRef, ok := ref["$ref"]; ok {
+					absPath, err := filepath.Abs(filepath.Join(filepath.Dir(dpFile), saRef))
+					if err != nil {
+						return err
+					}
+					ref["$ref"] = absPath
+
+					if !slices.Contains(resolvedSas, absPath) {
+
+						relativeSas := []string{}
+						for _, absSaPath := range resolvedSas {
+							relPath, err := filepath.Rel(filepath.Dir(dpFile), absSaPath)
+							if err != nil {
+								snplog.LogFatal(err)
+							}
+							relativeSas = append(relativeSas, relPath)
+						}
+
+						v.Errors = append(v.Errors, fmt.Sprintf(
+							"event spec source app not in parent data product list (event spec: %s, source app: %s), available list %v",
+							spec.ResourceName,
+							saRef,
+							relativeSas,
+						))
+					}
+				}
+			}
+		}
+
+		lookup.Validations[dpFile] = v
+	}
+
+	return nil
+}
+
+func (lookup *DPLookup) SlogValidations(basePath string) error {
+	for f, v := range lookup.Validations {
+		rp, err := filepath.Rel(basePath, f)
+		if err != nil {
+			return err
+		}
+		for _, m := range v.Debug {
+			slog.Debug("validating", "file", rp, "msg", m)
+		}
+		for _, m := range v.Info {
+			slog.Info("validating", "file", rp, "msg", m)
+		}
+		for _, m := range v.Warnings {
+			slog.Warn("validating", "file", rp, "msg", m)
+		}
+		for _, m := range v.Errors {
+			slog.Error("validating", "file", rp, "msg", m)
+		}
+	}
+
+	return nil
+}
+
+func (lookup *DPLookup) GhAnnotateValidations(basePath string) error {
+
+	for f, v := range lookup.Validations {
+		rp, err := filepath.Rel(basePath, f)
+		if err != nil {
+			return err
+		}
+		if len(v.Info) > 0 {
+			fmt.Printf("::info file=%s::%s\n", rp, strings.Join(v.Info, "%0A"))
+		}
+		if len(v.Warnings) > 0 {
+			fmt.Printf("::warn file=%s::%s\n", rp, strings.Join(v.Warnings, "%0A"))
+		}
+		if len(v.Errors) > 0 {
+			fmt.Printf("::error file=%s::%s\n", rp, strings.Join(v.Errors, "%0A"))
+		}
+	}
+
+	return nil
+}
+
+func (lookup *DPLookup) ValidationErrorCount() int {
+	count := 0
+	for _, v := range lookup.Validations {
+		count += len(v.Errors)
+	}
+	return count
+}

--- a/internal/validation/local_dp_validation_test.go
+++ b/internal/validation/local_dp_validation_test.go
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd.
+ * All rights reserved.
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package validation
+
+import (
+	"testing"
+)
+
+func Test_DPLookup_RelativePaths(t *testing.T) {
+	input := map[string]map[string]any{
+		"/base/source-apps/a/b/file1.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "source-application",
+		},
+		"/base/source-apps/a/file1.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "source-application",
+		},
+		"/base/somedir/file2.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "data-product",
+			"data": map[string]any{
+				"sourceApplications": []map[string]string{
+					{"$ref": "../source-apps/a/../a/file1.yml"},
+					{"$ref": "../source-apps/a/../a/b/../b/file1.yml"},
+				},
+			},
+		},
+	}
+
+	lookup, err := NewDPLookup(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, ok := lookup.DataProducts["/base/somedir/file2.yml"]
+	if !ok {
+		t.Fatal("couldnt find expected")
+	}
+
+	refs := [2]string{
+		v.Data.SourceApplications[0]["$ref"],
+		v.Data.SourceApplications[1]["$ref"],
+	}
+
+	if refs != [2]string{"/base/source-apps/a/file1.yml", "/base/source-apps/a/b/file1.yml"} {
+		t.Fatal("missing paths", refs)
+	}
+}
+
+func Test_DPLookup_EventSpecBadSourceApp(t *testing.T) {
+	input := map[string]map[string]any{
+		"/base/somedir/file1.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "source-application",
+		},
+		"/base/somedir/file2.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "data-product",
+			"data": map[string]any{
+				"sourceApplications": []map[string]string{
+					{"$ref": "file1.yml"},
+				},
+				"eventSpecifications": []map[string]any{
+					{
+						"sourceApplications": []map[string]string{
+							{"$ref": "file7.yml"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	lookup, err := NewDPLookup(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, ok := lookup.Validations["/base/somedir/file2.yml"]
+	if !ok {
+		t.Fatal("couldnt find expected")
+	}
+
+	if len(v.Errors) != 1 {
+		t.Fatal("expected bad event spec source app $ref error")
+	}
+}
+
+func Test_DPLookup_Resolved(t *testing.T) {
+	input := map[string]map[string]any{
+		"/base/somedir/file1.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "source-application",
+		},
+		"/base/somedir/file2.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "data-product",
+			"data": map[string]any{
+				"sourceApplications": []map[string]string{
+					{"$ref": "file1.yml"},
+				},
+			},
+		},
+	}
+
+	lookup, err := NewDPLookup(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, ok := lookup.DataProducts["/base/somedir/file2.yml"]
+	if !ok {
+		t.Fatal("couldnt find expected")
+	}
+
+	if v.Data.SourceApplications[0]["$ref"] != "/base/somedir/file1.yml" {
+		t.Fatal("bad path", v.Data.SourceApplications)
+	}
+}
+
+func Test_DPLookup_Ignored(t *testing.T) {
+	input := map[string]map[string]any{
+		"somedir/file1.yml": {
+			"apiVersion": "v1",
+		},
+		"somedir/file2.yml": {
+			"apiVersion":   "v1",
+			"resourceType": "nothingtoseehere",
+		},
+	}
+
+	lookup, err := NewDPLookup(input)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, ok := lookup.Validations["somedir/file1.yml"]
+
+	if !ok {
+		t.Fatal("validation success?")
+	}
+
+	if v.Errors[0] != "missing resourceType" {
+		t.Fatal("wrong error", v.Errors)
+	}
+
+	v, ok = lookup.Validations["somedir/file2.yml"]
+
+	if !ok {
+		t.Fatal("validation success?")
+	}
+
+	if len(v.Errors) != 1 {
+		t.Fatal("no error?")
+	}
+}

--- a/internal/validation/local_dp_validation_test.go
+++ b/internal/validation/local_dp_validation_test.go
@@ -160,7 +160,7 @@ func Test_DPLookup_Ignored(t *testing.T) {
 		t.Fatal("validation success?")
 	}
 
-	if len(v.Errors) != 1 {
-		t.Fatal("no error?")
+	if len(v.Debug) != 1 {
+		t.Fatal("no debug?")
 	}
 }


### PR DESCRIPTION
I'm not sure i like this, but i'm not sitting on it.

Essentially:
1. load everything we can find as (string, any)
2. error if its not something we recognise (i don't think this should be an error, maybe)
3. decode as a dp/sa type
4. convert all `dp.data.sourceapp.refs` to absolute paths and make sure they exist 
5. run through all event specs and make sure they refer to a source app in the parent dp list