### PR TITLE
[DP-XXX] DP cwd resolution

### DIFF
--- a/cmd/dp/publish.go
+++ b/cmd/dp/publish.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/snowplow-product/snowplow-cli/internal/console"
 	snplog "github.com/snowplow-product/snowplow-cli/internal/logging"
@@ -56,11 +55,10 @@ If no directory is provided then defaults to 'data-products' in the current dire
 			snplog.LogFatal(err)
 		}
 
-		arg0, err := os.Executable()
+		basePath, err := os.Getwd()
 		if err != nil {
 			snplog.LogFatal(err)
 		}
-		basePath := filepath.Dir(arg0)
 
 		cnx := context.Background()
 

--- a/cmd/dp/validate.go
+++ b/cmd/dp/validate.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/snowplow-product/snowplow-cli/internal/console"
 	snplog "github.com/snowplow-product/snowplow-cli/internal/logging"
@@ -54,11 +53,10 @@ var validateCmd = &cobra.Command{
 			snplog.LogFatal(err)
 		}
 
-		arg0, err := os.Executable()
+		basePath, err := os.Getwd()
 		if err != nil {
 			snplog.LogFatal(err)
 		}
-		basePath := filepath.Dir(arg0)
 
 		cnx := context.Background()
 


### PR DESCRIPTION
Everything was resolving fine as we convert to abs paths. The issue was validation reporting where it attempts to loose the absolute bit and give you something a bit more digestible. So say you had your exe in /usr/local/bin. Validation would attempt to give you relative path from there to the data product, resulting in `../../../Users/xxxx/blah` which makes it less digestible.