### PR TITLE
[Hotfix] Add missing event spec description

### DIFF
--- a/internal/console/requests_dp.go
+++ b/internal/console/requests_dp.go
@@ -46,6 +46,7 @@ type RemoteEventSpec struct {
 	SourceApplicationIds []string      `json:"sourceApplications"`
 	Name                 string        `json:"name"`
 	Status               string        `json:"status"`
+	Description          string        `json:"description"`
 	Version              int           `json:"version"`
 	Event                *EventWrapper `json:"event,omitempty"`
 	Entities             Entities      `json:"entities"`

--- a/internal/download/mappings.go
+++ b/internal/download/mappings.go
@@ -100,6 +100,7 @@ func remoteEsToLocal(remoteEs console.RemoteEventSpec, saIdToRef map[string]mode
 		ResourceName:               remoteEs.Id,
 		ExcludedSourceApplications: excludedSourceApps,
 		Name:                       remoteEs.Name,
+		Description:                remoteEs.Description,
 		Event:                      event,
 		Entities:                   entities,
 	}

--- a/internal/model/data_products.go
+++ b/internal/model/data_products.go
@@ -14,6 +14,7 @@ type EventSpec struct {
 	ResourceName               string
 	ExcludedSourceApplications []map[string]string `yaml:"excludedSourceApplications,omitempty" json:"excludedSourceApplications,omitempty"`
 	Name                       string
+	Description                string
 	Event                      SchemaRef
 	Entities                   EntitiesDef
 }
@@ -77,6 +78,7 @@ type EventSpecCanonical struct {
 	ResourceName               string `yaml:"resourceName" json:"resourceName"`
 	ExcludedSourceApplications []Ref  `yaml:"excludedSourceApplications,omitempty" json:"excludedSourceApplications,omitempty"`
 	Name                       string
+	Description                string    `yaml:"description,omitempty" json:"description,omitempty"`
 	Event                      SchemaRef `yaml:"event,omitempty" json:"event,omitempty"`
 	Entities                   EntitiesDef
 }

--- a/internal/publish/mappings.go
+++ b/internal/publish/mappings.go
@@ -113,6 +113,7 @@ func LocalEventSpecToRemote(es model.EventSpec, dpSourceApps []string, dpId stri
 		Id:                   es.ResourceName,
 		SourceApplicationIds: sourceApps,
 		Name:                 es.Name,
+		Description:          es.Description,
 		Event:                &console.EventWrapper{Event: event},
 		Entities:             entities,
 		DataProductId:        dpId,
@@ -122,6 +123,7 @@ func LocalEventSpecToRemote(es model.EventSpec, dpSourceApps []string, dpId stri
 type RemoteEventSpecDiff struct {
 	SourceApplicationIds []string
 	Name                 string
+	Description          string
 	Event                string
 	Entities             EntitiesDiff
 	DataProductId        string
@@ -178,6 +180,7 @@ func esToDiff(es console.RemoteEventSpec) (*RemoteEventSpecDiff, error) {
 	return &RemoteEventSpecDiff{
 		SourceApplicationIds: sourceApps,
 		Name:                 es.Name,
+		Description:          es.Description,
 		Event:                string(eventJson),
 		Entities:             EntitiesDiff{Tracked: tracked, Enriched: enriched},
 		DataProductId:        es.DataProductId,

--- a/internal/validation/schema/data-product.json
+++ b/internal/validation/schema/data-product.json
@@ -45,6 +45,7 @@
                 }
               },
               "name": { "type": "string", "minLength": 1 },
+              "description": { "type": "string", "minLength": 1 },
               "event": {
                 "type": "object",
                 "additionalProperties": false,


### PR DESCRIPTION
We totally need to reduce the amount of event spec models at least by one