### PR TITLE
[DPS-647] Locking data products and source apps

### DIFF
--- a/cmd/dp/publish.go
+++ b/cmd/dp/publish.go
@@ -39,6 +39,7 @@ If no directory is provided then defaults to 'data-products' in the current dire
 		org, _ := cmd.Flags().GetString("org-id")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		ghOut, _ := cmd.Flags().GetBool("gh-annotate")
+		managedFrom, _ := cmd.Flags().GetString("managed-from")
 
 		searchPaths := []string{}
 
@@ -70,6 +71,8 @@ If no directory is provided then defaults to 'data-products' in the current dire
 		if err != nil {
 			snplog.LogFatal(err)
 		}
+
+		publish.LockChanged(changes, managedFrom)
 
 		validation.Validate(cnx, c, files, searchPaths, basePath, ghOut, false, changes.IdToFileName)
 

--- a/internal/console/requests_dp.go
+++ b/internal/console/requests_dp.go
@@ -35,6 +35,8 @@ type RemoteDataProduct struct {
 	Owner                string               `json:"owner,omitempty"`
 	Description          string               `json:"description,omitempty"`
 	EventSpecs           []EventSpecReference `json:"eventSpecs"`
+	LockStatus           string               `json:"lockStatus,omitempty"`
+	ManagedFrom          string               `json:"managedFrom,omitempty"`
 }
 
 type EventSpecReference struct {
@@ -95,6 +97,8 @@ type RemoteSourceApplication struct {
 	Owner       string   `json:"owner,omitempty"`
 	AppIds      []string `json:"appIds"`
 	Entities    Entities `json:"entities"`
+	LockStatus  string   `json:"lockStatus,omitempty"`
+	ManagedFrom string   `json:"managedFrom,omitempty"`
 }
 
 type Entities struct {

--- a/internal/publish/logic_dp.go
+++ b/internal/publish/logic_dp.go
@@ -186,7 +186,7 @@ func findChanges(local LocalFilesRefsResolved, remote console.DataProductsAndRel
 
 		if remoteExists {
 			possibleUpdate := localSaToRemote(localSa)
-			if !reflect.DeepEqual(possibleUpdate, currentRemote) {
+			if !reflect.DeepEqual(saToDiff(possibleUpdate), saToDiff(currentRemote)) {
 				saUpdate = append(saUpdate, possibleUpdate)
 				idToFileName[localSa.ResourceName] = local.IdToFileName[localSa.ResourceName]
 			}
@@ -586,4 +586,31 @@ func Publish(cnx context.Context, client *console.ApiClient, changeSet *DataProd
 		err = ApplyDpChanges(*changeSet, cnx, client)
 	}
 	return err
+}
+
+func LockChanged(changeSet *DataProductChangeSet, managedFrom string) {
+	for i := range changeSet.dpCreate {
+		changeSet.dpCreate[i].LockStatus = "locked"
+		if managedFrom != "" {
+			changeSet.dpCreate[i].ManagedFrom = managedFrom
+		}
+	}
+	for i := range changeSet.dpUpdate {
+		changeSet.dpUpdate[i].LockStatus = "locked"
+		if managedFrom != "" {
+			changeSet.dpUpdate[i].ManagedFrom = managedFrom
+		}
+	}
+	for i := range changeSet.saCreate {
+		changeSet.saCreate[i].LockStatus = "locked"
+		if managedFrom != "" {
+			changeSet.saCreate[i].ManagedFrom = managedFrom
+		}
+	}
+	for i := range changeSet.saUpdate {
+		changeSet.saUpdate[i].LockStatus = "locked"
+		if managedFrom != "" {
+			changeSet.saUpdate[i].ManagedFrom = managedFrom
+		}
+	}
 }

--- a/internal/publish/logic_dp_test.go
+++ b/internal/publish/logic_dp_test.go
@@ -628,3 +628,32 @@ func Test_findTriggerChanges_MissingOriginal(t *testing.T) {
 	}
 
 }
+
+func Test_LockChanged(t *testing.T) {
+	changeSet := &DataProductChangeSet{
+		dpCreate: []console.RemoteDataProduct{{}},
+		dpUpdate: []console.RemoteDataProduct{{}},
+		saCreate: []console.RemoteSourceApplication{{}},
+		saUpdate: []console.RemoteSourceApplication{{}},
+	}
+
+	LockChanged(changeSet, "my repo")
+
+	results := []bool{
+		changeSet.dpCreate[0].LockStatus == "locked",
+		changeSet.dpCreate[0].ManagedFrom == "my repo",
+		changeSet.dpUpdate[0].LockStatus == "locked",
+		changeSet.dpUpdate[0].ManagedFrom == "my repo",
+
+		changeSet.saCreate[0].LockStatus == "locked",
+		changeSet.saCreate[0].ManagedFrom == "my repo",
+		changeSet.saUpdate[0].LockStatus == "locked",
+		changeSet.saUpdate[0].ManagedFrom == "my repo",
+	}
+
+	for i, r := range results {
+		if !r {
+			t.Errorf("lockstatus or managedfrom failure at i:%d", i)
+		}
+	}
+}

--- a/internal/publish/mappings.go
+++ b/internal/publish/mappings.go
@@ -220,3 +220,9 @@ func dpToDiff(dp console.RemoteDataProduct) RemoteDataProductDiff {
 		Description:          dp.Description,
 	}
 }
+
+func saToDiff(sa console.RemoteSourceApplication) console.RemoteSourceApplication {
+	sa.LockStatus = ""
+	sa.ManagedFrom = ""
+	return sa
+}

--- a/internal/publish/mappings_test.go
+++ b/internal/publish/mappings_test.go
@@ -242,3 +242,17 @@ func TestDpToDiff(t *testing.T) {
 		t.Errorf("Description = %v, want %v", result.Description, input.Description)
 	}
 }
+
+func Test_saToDiff(t *testing.T) {
+	input := console.RemoteSourceApplication{
+		Id: "id",
+		LockStatus: "locked",
+		ManagedFrom: "somewhere",
+	}
+
+	result := saToDiff(input)
+
+	if result.LockStatus != "" && result.ManagedFrom != "" {
+		t.Errorf("failed to setup remote source app for sensible comparison")
+	}
+}


### PR DESCRIPTION
Nothing remarkable I don't think. Should be behaving in the same way as data structures, ie: lock on publish and send managed from when supplied.